### PR TITLE
pygwalker 0.4.9.15

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/kanaries-track-feedstock/pr1/398acb7
-  - https://staging.continuum.io/preprod-pbp/fs/ipylab-feedstock/pr1/482566f
-  - https://staging.continuum.io/preprod-pbp/fs/segment-analytics-python-feedstock/pr2/574f6e6
-  - https://staging.continuum.io/pbp/fs/python-quickjs-feedstock/pr1/ed06515

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/kanaries-track-feedstock/pr1/398acb7
+  - https://staging.continuum.io/preprod-pbp/fs/ipylab-feedstock/pr1/482566f
+  - https://staging.continuum.io/preprod-pbp/fs/segment-analytics-python-feedstock/pr2/574f6e6
+  - https://staging.continuum.io/pbp/fs/python-quickjs-feedstock/pr1/ed06515

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 747b726e8acd35f20aef8ee74652a948575fb70b5fa8f816a692c9870d0ab0cb
 
 build:
+  # python-quickjs is not available on windows
   skip: true  # [py<37 or win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --ignore-installed
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,34 +22,40 @@ requirements:
     - hatch-jupyter-builder
   run:
     - python
-    - ipython
     - jinja2
-    - pandas
-    - typing_extensions
+    - ipython
     - astor
+    - typing_extensions
     - ipywidgets
     - pydantic
     - psutil
-    - python-duckdb >=0.10.0
+    - python-duckdb >=0.10.1,<2.0.0
     - pyarrow
     - sqlglot >=23.15.8
     - requests
     - arrow
     - sqlalchemy
-    - analytics-python ==2.2.2
+    - gw-dsl-parser ==0.1.49.1
     - appdirs
+    - segment-analytics-python ==2.2.3
+    - pandas
     - pytz
     - kanaries-track ==0.0.5
     - cachetools
     - packaging
     - numpy <2.0.0
     - ipylab <=1.0.0
+    - python-quickjs
+    - traitlets
+    - anywidget
 
 test:
   imports:
     - pygwalker
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://kanaries.net/pygwalker

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - kanaries-track ==0.0.5
     - cachetools
     - packaging
-    - numpy <2.0.0
+    - numpy
     - ipylab <=1.0.0
     - python-quickjs
     - traitlets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 747b726e8acd35f20aef8ee74652a948575fb70b5fa8f816a692c9870d0ab0cb
 
 build:
-  skip: true  # [py<37]
+  skip: true  # [py<37 or win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --ignore-installed
   number: 0
 
@@ -45,7 +45,7 @@ requirements:
     - packaging
     - numpy
     - ipylab <=1.0.0
-    - python-quickjs  # [not win]
+    - python-quickjs
     - traitlets
     - anywidget
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - packaging
     - numpy
     - ipylab <=1.0.0
-    - python-quickjs
+    - python-quickjs  # [not win]
     - traitlets
     - anywidget
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,18 +10,18 @@ source:
   sha256: 747b726e8acd35f20aef8ee74652a948575fb70b5fa8f816a692c9870d0ab0cb
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --ignore-installed
   number: 0
 
 requirements:
   host:
-    - python >=3.6,<4.0
+    - python
     - pip
     - hatchling
     - hatch-jupyter-builder
   run:
-    - python >=3.6,<4.0
+    - python
     - ipython
     - jinja2
     - pandas
@@ -52,10 +52,14 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/pygwalker/
-  summary: 'pygwalker: Combining Jupyter Notebook with a Tableau-like UI'
+  home: https://kanaries.net/pygwalker
+  summary: Combining Jupyter Notebook with a Tableau-like UI
+  description: PyGWalker can simplify your Jupyter Notebook data analysis and data visualization workflow, by turning your pandas dataframe into an interactive user interface for visual exploration.
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  doc_url: https://kanaries.net/pygwalker
+  dev_url: https://github.com/Kanaries/pygwalker
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-9838](https://anaconda.atlassian.net/browse/PKG-9838) 
- [Upstream repository](https://github.com/Kanaries/pygwalker/tree/0.4.9.15)
- [Upstream changelog/diff](https://github.com/Kanaries/pygwalker/releases)
- https://package-build.anaconda.com/v1/graph/971ead35-4fa6-4db9-bf71-9b4e37deca24
- Relevant dependency PRs:
  - [PKG-8402](https://anaconda.atlassian.net/browse/PKG-8402)

### Explanation of changes:

- Update version and sha256
- Update dependencies
- Skip windows

[PKG-9838]: https://anaconda.atlassian.net/browse/PKG-9838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-8402]: https://anaconda.atlassian.net/browse/PKG-8402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ